### PR TITLE
Redirect error messages to stderr and fix img-convert not failing when appropriate

### DIFF
--- a/kelvim-img-convert.sh
+++ b/kelvim-img-convert.sh
@@ -13,7 +13,8 @@ get_source_image_format() {
     local source_image="$1"
     local source_image_format
 
-    if source_image_format=$(qemu-img info "$source_image" | grep -oP '(?<=file format: ).*'); then
+    if ! source_image_format=$(qemu-img info "$source_image" | grep -oP '(?<=file format: ).*'); then
+      echo "$source_image_format" >&2
       exit 1
     fi
 
@@ -34,7 +35,7 @@ set_format_flag() {
             echo "-f vmdk"
             ;;
         *)
-            echo -e "${color_red}\nUnsupported source image format: $source_image_format${color_end}\n"
+            echo -e "${color_red}\nUnsupported source image format: $source_image_format${color_end}\n" >&2
             exit 1
             ;;
     esac
@@ -54,7 +55,7 @@ set_output_format_flag() {
             echo "-O vmdk"
             ;;
         *)
-            echo -e "${color_red}\nUnsupported output image format: $output_image_format${color_end}\n"
+            echo -e "${color_red}\nUnsupported output image format: $output_image_format${color_end}\n" >&2
             exit 1
             ;;
     esac
@@ -149,6 +150,6 @@ convert_image() {
 if [ $# -eq 3 ]; then
     convert_image "$@"
 else
-    echo -e "${color_red}\nUsage: $0 output_format source_image target_image${color_end}\n"
+    echo -e "${color_red}\nUsage: $0 output_format source_image target_image${color_end}\n" >&2
     exit 1
 fi

--- a/kelvim-snapshot-creator.sh
+++ b/kelvim-snapshot-creator.sh
@@ -38,7 +38,7 @@ while [[ "$#" -gt 0 ]]; do
             shift 2
             ;;
         *)
-            echo "Unknown option: $1"
+            echo "Unknown option: $1" 1>&2
             exit 1
             ;;
     esac
@@ -59,7 +59,7 @@ fi
 if [ -z "$frequency" ]; then
     frequency="daily"  # Default to daily if not specified
 elif [[ ! "$frequency" =~ ^(daily|weekly|monthly|yearly)$ ]]; then
-    echo -e "${color_red}Error: Invalid frequency. Must be daily, weekly, monthly, or yearly. Exiting.${color_end}"
+    echo -e "${color_red}Error: Invalid frequency. Must be daily, weekly, monthly, or yearly. Exiting.${color_end}" >&2
     exit 1
 fi
 
@@ -99,7 +99,7 @@ if [ -n "$external_target" ]; then
         ext_backup_target="$external_target"
         external=true
     else
-        echo -e "${color_red}Error: The specified external target directory does not exist. Aborting!${color_end}"
+        echo -e "${color_red}Error: The specified external target directory does not exist. Aborting!${color_end}" >&2
         exit 1
     fi
 else

--- a/kelvim-snapshot-lister.sh
+++ b/kelvim-snapshot-lister.sh
@@ -7,7 +7,7 @@ while [[ "$#" -gt 0 ]]; do
             shift 2
             ;;
         *)
-            echo "Unknown option: $1"
+            echo "Unknown option: $1" >&2
             exit 1
             ;;
     esac

--- a/kelvim-snapshot-restorer.sh
+++ b/kelvim-snapshot-restorer.sh
@@ -19,7 +19,7 @@ while [[ "$#" -gt 0 ]]; do
             shift 2
             ;;
         *)
-            echo "Unknown option: $1"
+            echo "Unknown option: $1" >&2
             exit 1
             ;;
     esac

--- a/kelvim-snapshot-sanitizer.sh
+++ b/kelvim-snapshot-sanitizer.sh
@@ -7,7 +7,7 @@ while [[ "$#" -gt 0 ]]; do
             shift 2
             ;;
         *)
-            echo "Unknown option: $1"
+            echo "Unknown option: $1" >&2
             exit 1
             ;;
     esac


### PR DESCRIPTION
- fixed `kelvim-img-convert.sh` failing at the wrong time (which I wrongly introduced in 278790e, sorry about that)
- set all the error messages to output to `stderr`